### PR TITLE
add *.exe to gitignore, and fix several warnings from gcc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 linenoise_example
+*.exe

--- a/linenoise.c
+++ b/linenoise.c
@@ -526,7 +526,7 @@ static void clearScreen(struct current *current)
 
 static void cursorToLeft(struct current *current)
 {
-    COORD pos = { 0, current->y };
+    COORD pos = { 0, (SHORT)current->y };
     DWORD n;
 
     FillConsoleOutputAttribute(current->outh,
@@ -536,7 +536,7 @@ static void cursorToLeft(struct current *current)
 
 static int outputChars(struct current *current, const char *buf, int len)
 {
-    COORD pos = { current->x, current->y };
+    COORD pos = { (SHORT)current->x, (SHORT)current->y };
     DWORD n;
 	
     WriteConsoleOutputCharacter(current->outh, buf, len, pos, &n);
@@ -546,7 +546,7 @@ static int outputChars(struct current *current, const char *buf, int len)
 
 static void outputControlChar(struct current *current, char ch)
 {
-    COORD pos = { current->x, current->y };
+    COORD pos = { (SHORT)current->x, (SHORT)current->y };
     DWORD n;
 
     FillConsoleOutputAttribute(current->outh, BACKGROUND_INTENSITY, 2, pos, &n);
@@ -556,7 +556,7 @@ static void outputControlChar(struct current *current, char ch)
 
 static void eraseEol(struct current *current)
 {
-    COORD pos = { current->x, current->y };
+    COORD pos = { (SHORT)current->x, (SHORT)current->y };
     DWORD n;
 
     FillConsoleOutputCharacter(current->outh, ' ', current->cols - current->x, pos, &n);
@@ -564,7 +564,7 @@ static void eraseEol(struct current *current)
 
 static void setCursorPos(struct current *current, int x)
 {
-    COORD pos = { x, current->y };
+    COORD pos = { (SHORT)x, (SHORT)current->y };
 
     SetConsoleCursorPosition(current->outh, pos);
     current->x = x;


### PR DESCRIPTION
hi Steve,

I found your linenoise has windows console support, that's awesome! I can use it with lua.lua on windows, thank you!

but I found some warnings in linenoise.c, so I fix it :-)

another question: why function linenoise using strdup? why not just receive a char\* buffer and a size? a strdup means a memory allocation and a strcpy! dont't know why linenoise do that.
