### PR TITLE
Allow tab-completion only at the end of line and replace magic number

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -955,7 +955,7 @@ static int linenoisePrompt(struct current *current) {
         /* Only autocomplete when the callback is set. It returns < 0 when
          * there was an error reading from fd. Otherwise it will return the
          * character that should be handled next. */
-        if (c == '\t' && completionCallback != NULL) {
+        if (c == '\t' && current->pos == current->chars && completionCallback != NULL) {
             c = completeLine(current);
             /* Return on errors */
             if (c < 0) return current->len;


### PR DESCRIPTION
Currently tab-completion may take place at arbitrary cursor positions, but there is no way to figure out the cursor position from within the line completion code, effectively preventing sensible completion at that place. Hence I limited tab-completion to the end of line, to prevent user confusion.

I also replaced the magic 9 in that line with '\t'.
