### PR TITLE
Bug fix. Reset size information when clearing the history.

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -187,6 +187,7 @@ void linenoiseHistoryFree(void) {
             free(history[j]);
         free(history);
         history = NULL;
+	history_len = 0;
     }
 }
 


### PR DESCRIPTION
Otherwise the next historyAdd will access freed memory, and crash.
