### PR TITLE
New feature: Extended character transpose (Ctrl+t) at end of the line.

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1124,6 +1124,14 @@ process_char:
                 insert_char(current, current->pos - 1, c);
                 refreshLine(current->prompt, current);
             }
+	    /* Transposition with cursor at the end is possible, take
+	     * the last 2 characters. This is how bash does it. */
+            else if (current->pos == current->chars) {
+                c = get_char(current, current->pos-1);
+                remove_char(current, current->pos-1);
+                insert_char(current, current->pos - 1, c);
+                refreshLine(current->prompt, current);
+            }
             break;
         case ctrl('V'):    /* ctrl-v */
             if (has_room(current, 3)) {


### PR DESCRIPTION
Bash is able to transpose characters with the cursor after the last
character. It simply transposes the last two. Added this behavior
to linenoise.
