### PR TITLE
New feature: Export console width through accessor API

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1253,6 +1253,15 @@ history_navigation:
     return current->len;
 }
 
+int linenoiseColumns(void)
+{
+    struct current current;
+    enableRawMode (&current);
+    getWindowSize (&current);
+    disableRawMode (&current);
+    return current.cols;
+}
+
 char *linenoise(const char *prompt)
 {
     int count;

--- a/linenoise.h
+++ b/linenoise.h
@@ -56,5 +56,6 @@ int linenoiseHistorySave(const char *filename);
 int linenoiseHistoryLoad(const char *filename);
 void linenoiseHistoryFree(void);
 char **linenoiseHistory(int *len);
+int linenoiseColumns(void);
 
 #endif /* __LINENOISE_H */


### PR DESCRIPTION
This change extends the linenoise API with a function returning the terminal width to the caller. It uses the internal getWindowSize() to determine the value.

Note: This pull request implicitly contains the pending pull requests/branches
  feature-cut-paste-buffer
  feature-hidden-input
  feature-page-updown

My use case was help texts printed to the terminal and the printing code auto-adapting the formatting to the terminal width.
