### PR TITLE
Bugfix: Compensate for ANSI color control sequences in the prompt

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -383,9 +383,9 @@ static int fd_read(struct current *current)
 
 static int countColorControlChars(char* prompt, int plen)
 {
-    /* ansi color control sequences have the form:
+    /* ANSI color control sequences have the form:
      * "\x1b" "[" [0-9;]+ "m"
-     * We parse with a simple state machine.
+     * We parse them with a simple state machine.
      */
 
     enum {
@@ -695,8 +695,10 @@ static int fd_read(struct current *current)
 
 static int countColorControlChars(char* prompt, int plen)
 {
-  /* For windows we assume that there are no embedded ansi color control sequences */
-  return 0;
+    /* For windows we assume that there are no embedded ansi color
+     * control sequences.
+     */
+    return 0;
 }
 
 static int getWindowSize(struct current *current)


### PR DESCRIPTION
The main change in this pull request is additional code in refreshLine which parses ANSI color control sequences out of the prompt and discounts them as actual columns.

Without this change the existing code will put the input area to far to the right of the prompt. My tcl-linenoise repository has an example where the input starts 9 characters to far to the right without this fix.

Use case is a partially colored prompt, highlighting a/the default value of the input as part of the prompt.

Note: This pull request implicitly contains the pending feature branches
  feature-cut-paste-buffer
  feature-export-get-console-width
  feature-hidden-input
  feature-page-updown
