### PR TITLE
fix ctrl bug during reverse search

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -724,6 +724,8 @@ static int fd_read(struct current *current)
                 }
             }
             /* Note that control characters are already translated in AsciiChar */
+            else if (k->wVirtualKeyCode == VK_CONTROL)
+	        continue;
             else {
 #ifdef USE_UTF8
                 return k->uChar.UnicodeChar;


### PR DESCRIPTION
In the original code in win32, when you press ctrl(before press any other key)during reverse search,  you will directly exit search and return current match patter. This behavior is not correct.
