### PR TITLE
Clear some warnings and errors with GCC and MSVC.

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1016,8 +1016,10 @@ static void refreshEnd(struct current *current)
     current->output = NULL;
 }
 
-static void refreshStartChars()
+static void refreshStartChars(struct current *current)
 {
+    if (!current)
+        return;
 }
 
 static void refreshNewline(struct current *current)
@@ -1026,8 +1028,10 @@ static void refreshNewline(struct current *current)
     outputChars(current, "\n", 1);
 }
 
-static void refreshEndChars()
+static void refreshEndChars(struct current *current)
 {
+    if (!current)
+        return;
 }
 #endif
 

--- a/linenoise.c
+++ b/linenoise.c
@@ -227,15 +227,17 @@ void linenoiseHistoryFree(void) {
     }
 }
 
+typedef enum {
+    EP_START,   /* looking for ESC */
+    EP_ESC,     /* looking for [ */
+    EP_DIGITS,  /* parsing digits */
+    EP_PROPS,   /* parsing digits or semicolons */
+    EP_END,     /* ok */
+    EP_ERROR,   /* error */
+} ep_state_t;
+
 struct esc_parser {
-    enum {
-        EP_START,   /* looking for ESC */
-        EP_ESC,     /* looking for [ */
-        EP_DIGITS,  /* parsing digits */
-        EP_PROPS,   /* parsing digits or semicolons */
-        EP_END,     /* ok */
-        EP_ERROR,   /* error */
-    } state;
+    ep_state_t state;
     int props[5];   /* properties are stored here */
     int maxprops;   /* size of the props[] array */
     int numprops;   /* number of properties found */
@@ -342,7 +344,7 @@ static void DRL_STR(const char *str)
     }
 }
 #else
-#define DRL(ARGS...)
+#define DRL(...)
 #define DRL_CHAR(ch)
 #define DRL_STR(str)
 #endif
@@ -1014,7 +1016,7 @@ static void refreshEnd(struct current *current)
     current->output = NULL;
 }
 
-static void refreshStartChars(struct current *current)
+static void refreshStartChars()
 {
 }
 
@@ -1024,7 +1026,7 @@ static void refreshNewline(struct current *current)
     outputChars(current, "\n", 1);
 }
 
-static void refreshEndChars(struct current *current)
+static void refreshEndChars()
 {
 }
 #endif
@@ -1463,8 +1465,8 @@ static int reverseIncrementalSearch(struct current *current)
         c = fd_read(current);
         if (c == ctrl('H') || c == CHAR_DELETE) {
             if (rchars) {
-                int p = utf8_index(rbuf, --rchars);
-                rbuf[p] = 0;
+                int p_ind = utf8_index(rbuf, --rchars);
+                rbuf[p_ind] = 0;
                 rlen = strlen(rbuf);
             }
             continue;


### PR DESCRIPTION
Hi!  I had to make a few tweaks to the linenoise code to clear warnings encountered in BRL-CAD - would these be acceptable to push back upstream?