### PR TITLE
fix SEGV on redirected stdin with empty line

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1871,7 +1871,7 @@ static stringbuf *sb_getline(FILE *fh)
         /* ignore the effect of character count for partial utf8 sequences */
         sb_append_len(sb, &ch, 1);
     }
-    if (n == 0) {
+    if (n == 0 || sb->data == NULL) {
         sb_free(sb);
         return NULL;
     }


### PR DESCRIPTION
The example program, and any other program for that matter, will segfault if you pipe a file containing only a newline as input.

I discovered this while fuzzing one of my programs that happens to use your library.