### PR TITLE
Added explicit void to indicate beep function takes no arguments

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -814,7 +814,7 @@ static linenoiseHintsCallback *hintsCallback = NULL;
 static linenoiseFreeHintsCallback *freeHintsCallback = NULL;
 static void *hintsUserdata = NULL;
 
-static void beep() {
+static void beep(void) {
 #ifdef USE_TERMIOS
     fprintf(stderr, "\x7");
     fflush(stderr);


### PR DESCRIPTION
No change in functionality, this just allows linenoise to be built with `-Werror=strict-prototypes` when using GCC or clang.