### PR TITLE
Preserve curent background color on Windows

### DIFF
--- a/linenoise-win32.c
+++ b/linenoise-win32.c
@@ -73,6 +73,16 @@ static void disableRawMode(struct current *current)
     SetConsoleMode(current->inh, orig_consolemode);
 }
 
+static WORD sameBackground(HANDLE outh, WORD foreground)
+{
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    if (!GetConsoleScreenBufferInfo(outh, &csbi)) {
+        return foreground;
+    }
+    WORD attrs = csbi.wAttributes;
+    return (attrs & 0xfff0) | (foreground & 0xf);
+}
+
 void linenoiseClearScreen(void)
 {
     /* XXX: This is ugly. Should just have the caller pass a handle */
@@ -87,7 +97,7 @@ void linenoiseClearScreen(void)
         FillConsoleOutputCharacter(current.outh, ' ',
             current.cols * current.rows, topleft, &n);
         FillConsoleOutputAttribute(current.outh,
-            FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN,
+            sameBackground(current.outh, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN),
             current.cols * current.rows, topleft, &n);
         SetConsoleCursorPosition(current.outh, topleft);
     }
@@ -102,7 +112,8 @@ static void cursorToLeft(struct current *current)
     pos.Y = (SHORT)current->y;
 
     FillConsoleOutputAttribute(current->outh,
-        FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN, current->cols, pos, &n);
+        sameBackground(current->outh, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN),
+        current->cols, pos, &n);
     current->x = 0;
 }
 
@@ -214,10 +225,10 @@ static void outputNewline(struct current *current)
 
 static void setOutputHighlight(struct current *current, const int *props, int nprops)
 {
-    int colour = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN;
     int bold = 0;
     int reverse = 0;
     int i;
+    int colour = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN;
 
     for (i = 0; i < nprops; i++) {
         switch (props[i]) {
@@ -265,6 +276,7 @@ static void setOutputHighlight(struct current *current, const int *props, int np
         SetConsoleTextAttribute(current->outh, BACKGROUND_INTENSITY);
     }
     else {
+        colour = sameBackground(current->outh, colour);
         SetConsoleTextAttribute(current->outh, colour | bold);
     }
 }

--- a/linenoise-win32.c
+++ b/linenoise-win32.c
@@ -75,9 +75,9 @@ static void disableRawMode(struct current *current)
 
 static int color_accepted(void) {
     char *no_color = getenv("NO_COLOR");
-    bool accept = true;
+    int accept = 1;
     if (no_color != NULL && no_color[0] != '\0')
-            accept = false;
+            accept = 0;
     return accept;
 }
 

--- a/linenoise-win32.c
+++ b/linenoise-win32.c
@@ -73,6 +73,14 @@ static void disableRawMode(struct current *current)
     SetConsoleMode(current->inh, orig_consolemode);
 }
 
+static int color_accepted(void) {
+    char *no_color = getenv("NO_COLOR");
+    bool accept = true;
+    if (no_color != NULL && no_color[0] != '\0')
+            accept = false;
+    return accept;
+}
+
 static WORD sameBackground(HANDLE outh, WORD foreground)
 {
     CONSOLE_SCREEN_BUFFER_INFO csbi;
@@ -96,9 +104,11 @@ void linenoiseClearScreen(void)
 
         FillConsoleOutputCharacter(current.outh, ' ',
             current.cols * current.rows, topleft, &n);
-        FillConsoleOutputAttribute(current.outh,
-            sameBackground(current.outh, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN),
-            current.cols * current.rows, topleft, &n);
+        if (color_accepted()) {
+            FillConsoleOutputAttribute(current.outh,
+                sameBackground(current.outh, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN),
+                current.cols * current.rows, topleft, &n);
+        }
         SetConsoleCursorPosition(current.outh, topleft);
     }
 }
@@ -111,9 +121,11 @@ static void cursorToLeft(struct current *current)
     pos.X = 0;
     pos.Y = (SHORT)current->y;
 
-    FillConsoleOutputAttribute(current->outh,
-        sameBackground(current->outh, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN),
-        current->cols, pos, &n);
+    if (color_accepted()) {
+        FillConsoleOutputAttribute(current->outh,
+            sameBackground(current->outh, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN),
+            current->cols, pos, &n);
+    }
     current->x = 0;
 }
 
@@ -229,6 +241,11 @@ static void setOutputHighlight(struct current *current, const int *props, int np
     int reverse = 0;
     int i;
     int colour = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_GREEN;
+
+    if (!color_accepted()) {
+        return;
+    }
+
 
     for (i = 0; i < nprops; i++) {
         switch (props[i]) {


### PR DESCRIPTION
On Windows, instead of preserving the background color all color changes from linenoise destroyed it, enforcing black, even if other background color was to be used.
This change correctly preserves the background color of the output on Windows, whenever there's an attempt to change the foreground color.